### PR TITLE
Migrated to SharpImageService and Added "github-slugger" in package.json

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 import AutoImport from "astro-auto-import";
-import { defineConfig, squooshImageService } from "astro/config";
+import { defineConfig, sharpImageService } from "astro/config";
 import remarkCollapse from "remark-collapse";
 import remarkToc from "remark-toc";
 import config from "./src/config/config.json";
@@ -14,7 +14,7 @@ export default defineConfig({
   base: config.site.base_path ? config.site.base_path : "/",
   trailingSlash: config.site.trailing_slash ? "always" : "never",
   image: {
-    service: squooshImageService(),
+    service: sharpImageService(),
   },
   integrations: [
     react(),

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^3.0.1",
-    "@astrojs/rss": "^4.0.6",
     "@astrojs/react": "^3.4.0",
+    "@astrojs/rss": "^4.0.6",
     "@astrojs/sitemap": "^3.1.5",
     "@astrojs/tailwind": "^5.1.0",
     "astro": "^4.9.3",
@@ -18,6 +18,7 @@
     "astro-font": "^0.0.81",
     "date-fns": "^3.6.0",
     "fuse.js": "^7.0.0",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "marked": "^12.0.2",
     "react": "^18.3.1",


### PR DESCRIPTION
#24 
## Migrated to Sharp Image Service
In astro.config, changed `squooshImageService()` to `sharpImageService`   

## Missing Dependency __github-slugger__
added github-slugger in package.json